### PR TITLE
Set content length header in signature calculation as length of the utf-8 byte array of payload

### DIFF
--- a/no-sdk/java/HttpHelpers.java
+++ b/no-sdk/java/HttpHelpers.java
@@ -46,7 +46,7 @@ public class HttpHelpers {
         String payloadHash = AWSSigner.calculateHash(payload);
         Map<String, String> headers = new HashMap<>();
         headers.put("x-amz-content-sha256", payloadHash);
-        headers.put("content-length", String.valueOf(payload.length()));
+        headers.put("content-length", String.valueOf(payload.getBytes(StandardCharsets.UTF_8).length));
         headers.put("content-type", "application/json");
 
         String authorizationHeader = AWSSigner.getAuthorizationHeader(service, region, "POST", uri, now, headers, payloadHash);


### PR DESCRIPTION
*Issue #, if available:*
When payload contains non-ascii unicode chars, API Gateway returns 'The request signature we calculated does not match the signature you provided' error

*Description of changes:*
Updated HttpHelpers to set content length header in signature calculation as length of the utf-8 byte array of payload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
