### PR TITLE
update sdk node main.js: pass  path and query as separate parameters …

### DIFF
--- a/no-sdk/nodejs/main.js
+++ b/no-sdk/nodejs/main.js
@@ -25,8 +25,14 @@ const amzDate = `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
 const dateStamp = amzDate.slice(0, 8);
 
 // Create the canonical request
-const canonicalUri = endpoint;
-const canonicalQuerystring = '';
+// Parse URI and query string
+let canonicalUri, canonicalQuerystring;
+if (endpoint.includes('?')) {
+  [canonicalUri, canonicalQuerystring] = endpoint.split('?', 2);
+} else {
+  canonicalUri = endpoint;
+  canonicalQuerystring = '';
+}
 const requestBody = '';
 const requestBodyHash = crypto.createHash('sha256').update(requestBody).digest('hex');
 const headers = {
@@ -38,7 +44,7 @@ if (sessionToken) {
   headers['X-Amz-Security-Token'] = sessionToken;
 }
 
-const canonicalRequest = createCanonicalRequest(method, endpoint, canonicalQuerystring, headers, requestBodyHash);
+const canonicalRequest = createCanonicalRequest(method, canonicalUri, canonicalQuerystring, headers, requestBodyHash);
 
 // Create the string to sign
 const algorithm = 'AWS4-HMAC-SHA256';
@@ -116,7 +122,7 @@ const authorizationHeader = `${algorithm} Credential=${accessKey}/${credentialSc
 // Make the request
 const options = {
   hostname: host,
-  path: canonicalUri,
+  path: endpoint,
   method,
   headers: {
     ...headers,

--- a/sdk/nodejs/main.js
+++ b/sdk/nodejs/main.js
@@ -8,12 +8,16 @@ async function makeSignedRequest() {
   const sessionToken = process.env.AWS_SESSION_TOKEN;
   const service = 'execute-api';
   const host = process.env.RESTAPIHOST;
-  const canonicalURI = process.env.RESTAPIPATH;
+  const fullPath = process.env.RESTAPIPATH;
   const region = 'us-east-1';
+
+  // Parse path and query parameters
+  const [pathname, querystring] = fullPath.includes('?') ? fullPath.split('?') : [fullPath, ''];
+  const query = querystring ? Object.fromEntries(new URLSearchParams(querystring)) : {};
 
   const options = {
     hostname: host,
-    path: canonicalURI,
+    path: fullPath,
     method: 'GET',
     headers: {
       'Host': host,
@@ -35,7 +39,8 @@ async function makeSignedRequest() {
     method: options.method,
     headers: options.headers,
     hostname: host,
-    path: canonicalURI,
+    path: pathname,
+    query: query,
     protocol: 'https:'
   });
 


### PR DESCRIPTION
…to SignatureV4.sign()

`RESTAPIPATH=/dev/dataSourcesSummary?awsAccountId=353115813707`

The SignatureV4.sign() method expects path and query as separate parameters

Passing the entire path with query parameters as just the path caused incorrect canonical string generation.


```
node main.js
response Status: 403
response Body: {"message":"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.

The Canonical String for this request should have been
'GET
/dev/dataSourcesSummary
awsAccountId=353115813707
host:nk9p23ranf.execute-api.us-east-1.amazonaws.com
x-amz-content-sha256:xsffcdcdcdcxx
x-amz-date:20250731T231128Z
x-amz-security-token:dkjfdlsjfdskfhfdslsdcdlkdldfdfdffdf

host;x-amz-content-sha256;x-amz-date;x-amz-security-token
dfsfafdsfdsadfdfdfasfd'

The String-to-Sign should have been
'AWS4-HMAC-SHA256
20250731T231128Z
20250731/us-east-1/execute-api/aws4_request
cfe239ee2051f97238191936894de08afe6c1adf9149adfasfdsfdasfsadfdsf'
"}
```

*Description of changes:*

The fix separates the path and query parameters, then passes them correctly to the signing method

```
% node main.js
response Status: 200
response Body: {"dataSourceSummary":{"activeDataSources":26,"deletedDataSources":0}}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
